### PR TITLE
Dont change virtualenv if you're already in one

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,18 +1,19 @@
 #!/bin/bash
 
-if [ ! -d "venv" ]; then
-  echo "Creating virtual environment for ComfyUI Launcher..."
-  echo
-  echo
-  python3 -m venv venv
-  echo
-  echo
+if [[ -z "$VIRTUAL_ENV" ]]; then
+  if [ ! -d "venv" ]; then
+    echo "Creating virtual environment for ComfyUI Launcher..."
+    echo
+    echo
+    python3 -m venv venv
+    echo
+    echo
+  fi
+  . venv/bin/activate
 fi
-
 echo "Installing required packages..."
 echo
 echo
-. venv/bin/activate
 pip install -r requirements.txt
 
 echo


### PR DESCRIPTION
I have a single venv for all my python projects so i don't want to re-create a new one just for this, does it make sense to check if we're already inside a venv before creating and activating a new one?

Sorry if this is not a good idea im new to python best practices